### PR TITLE
rewriting old file when saving with old name instead of throwing exception

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/Mp3File.java
+++ b/src/main/java/com/mpatric/mp3agic/Mp3File.java
@@ -439,9 +439,10 @@ public class Mp3File extends FileWrapper {
 		this.customTag = null;
 	}
 
-	public void save(String newFilename) throws IOException, NotSupportedException {
+	public void save(String suggestedNewFilename) throws IOException, NotSupportedException {
+		String newFilename = suggestedNewFilename;
 		if (path.toAbsolutePath().compareTo(Paths.get(newFilename).toAbsolutePath()) == 0) {
-			throw new IllegalArgumentException("Save filename same as source filename");
+			newFilename = newFilename + "_temp";
 		}
 		try (SeekableByteChannel saveFile = Files.newByteChannel(Paths.get(newFilename), EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE))) {
 			if (hasId3v2Tag()) {
@@ -461,6 +462,8 @@ public class Mp3File extends FileWrapper {
 				saveFile.write(byteBuffer);
 			}
 			saveFile.close();
+			if (!suggestedNewFilename.equals(newFilename))
+				new File(newFilename).renameTo(new File(suggestedNewFilename));
 		}
 	}
 

--- a/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
+++ b/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
@@ -108,29 +108,6 @@ public class Mp3FileTest {
 	}
 
 	@Test
-	public void shouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile() throws Exception {
-		Mp3File mp3File = new Mp3File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
-		testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(mp3File);
-	}
-
-	@Test
-	public void shouldThrowExceptionIfSavingMp3WithSameNameAsSourceFileForFileConstructor() throws Exception {
-		Mp3File mp3File = new Mp3File(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS));
-		testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(mp3File);
-	}
-
-	private void testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(Mp3File mp3File) throws NotSupportedException, IOException {
-		System.out.println(mp3File.getFilename());
-		System.out.println(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
-		try {
-			mp3File.save(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
-			fail("IllegalArgumentException expected but not thrown");
-		} catch (IllegalArgumentException e) {
-			assertEquals("Save filename same as source filename", e.getMessage());
-		}
-	}
-
-	@Test
 	public void shouldSaveLoadedMp3WhichIsEquivalentToOriginal() throws Exception {
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 41);
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 256);


### PR DESCRIPTION
the original library does not do this.